### PR TITLE
add requirements.txt with multihash lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyblake2==0.9.3
+pysha3==0.3
+-e git://github.com/JulienPalard/multihash.git@20ab39b#egg=multihash=


### PR DESCRIPTION
Hopefully settles https://github.com/ipfs/py-ipfs/issues/13 for the time being.  Tested with Python 3 (I'm able to import `multihash` successfully from a fresh virtualenv).
