### PR TITLE
Update Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,17 @@ setuptools.setup(
     tests_require=['pytest'],
     install_requires=['six'],
     cmdclass={'test': PyTest},
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: POSIX',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: System :: Filesystems',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, flake8
+envlist = py27, py34, py35, py36, flake8
 
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
Add modern versions of Python to the `tox` environment list and drop
no-longer-supported versions. Additionally, add Trove classifiers to
`setup.py` to specify supported Python versions, license, and other
metadata.